### PR TITLE
explain how endorsements are submitted during registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ How Does it Work?
 
 1.	A developer registers his or her application with the Endorsing Body (EB). Information collected includes many of the same elements used in an oAuth client application registration.  Items include the name, host name, and redirect URLs of the application.  
 2.	When approved by the EB, these values become memorialized and are embedded into a signed JWT, containing a software statement, that is given to the developer.  The EB's application registry contains one JSON document per certified application.  
-3.	An OAuth2 Server (OAuth2 Provider) may obtain a list of JWTs (i.e. a manifest) from a central source such as URL. Optionally, when an application developer is registering an application in the OAuth2 server, he or she may optionally include one or more JWT to the application registration.  The endorsement badge information will be displayed to the developer upon registration.
+3.	An OAuth2 Server (OAuth2 Provider) may obtain a list of JWTs (i.e. a manifest) from a central source such as URL. Optionally, when an application developer is registering an application in the OAuth2 server, he or she may optionally include one or more JWT to the application registration as a software statement (?).  The endorsement badge information will be displayed to the developer upon registration.
 4.	The badge and related information will be displayed to the end-user at the point of the oAuth2 client authorization.
 5.	While we anticipate all 3rd party applications will contain warnings to the end-user, when one or more valid badges are present, the warning language will be lessened. In the green, yellow, red, analogy the warning would become yellow.
 


### PR DESCRIPTION
The README doesn't explain how a client would present one or more software statements during a dynamic registration interaction. https://tools.ietf.org/html/rfc7591 suggests that the `software_statement` property could be used, but this would only allow for a single endorsement (it's a single-cardinality element, not an array). It's possible we could define a convention for presenting endorsements as an "Initial Access Token" (in a header), but either of these approaches will require further specification.